### PR TITLE
Handle the super rare edge case where FingerprintJS misidentifies the…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ const Protect = ({ sha512, blur, boxTitle, inputPlaceholder, buttonLabel, wrappe
       try {
         d = aes.decrypt(cipher, result.visitorId).toString(CryptoJS.enc.Utf8);
       } catch(e) {
-        d= ""
+        d = ""
       }
 
       if(d) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,12 @@ const Protect = ({ sha512, blur, boxTitle, inputPlaceholder, buttonLabel, wrappe
     (async function getFingerprint() {
       const fpi = await FingerprintJS.load();
       const result = await fpi.get();
-      const d = aes.decrypt(cipher, result.visitorId).toString(CryptoJS.enc.Utf8);
+      let d;
+      try {
+        d = aes.decrypt(cipher, result.visitorId).toString(CryptoJS.enc.Utf8);
+      } catch(e) {
+        d= ""
+      }
 
       if(d) {
         const hash = CryptoJS.SHA512(JSON.parse(d).pass).toString();


### PR DESCRIPTION
… user and CryptoJS returns a non-UTF sequence of bytes.

Closes #2 

According to [FingerprintJS's docs](https://dev.fingerprintjs.com/docs/quick-start-guide) there is a 0.5% change that the `visitorId` returned by its agent will misidentify the user. Because this `visitorId` is used by CryptoJS to decrypt the stored cipher value:
```
const d = aes.decrypt(cipher, result.visitorId).toString(CryptoJS.enc.Utf8);
```
this misidentification will cause the stored value to not be decrypted properly. According to the author of [this blog post](https://eclipsesource.com/blogs/2016/06/08/decoding-symmetric-cyphers-with-crypto-js/), his testing found that CryptoJS will just return an empty string 97% of the time if the decryption key (ie the `visitorId`) is changed. In the context of this package, that manifests as having to re-enter the password even though the cipher _should_ still be in your localStorage.

2.5% of the time however, CryptoJS will return a sequence of bytes that cannot be converted into a UTF-8 character sequence, causing a `Malformed UTF-8` error to be thrown. Because clearing your localStorage is not an obvious solution to this error message, I propose that we catch this error by setting d to an empty string. The user would then simply be prompted to enter their password and the should be good to go.

Even though the probability of this error occurring are 2.5% * 0.5% = **0.0125%**, it was really starting to get annoying after extended use.

This package has been really nice to have otherwise, and thanks for all the work you've put into it! :slightly_smiling_face: 